### PR TITLE
Add env variables for easy switch of local development and add setup instructions to readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ temp
 /update/artifacts/
 /update/index/
 /update/detail/
+/extension/extensions/
+**/WEB-INF/
 **/.DS_Store
 **/.svn/
 /*.project

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The repository mainly consists of the following directories:
 
 ## Installation for local development
 
-This documentation shows one quick example how to setup and run this repository locally, including the setup of the RESTful services to be served locally at [http://localhost:8888](http://localhost:8888) with Lucee Express for development.  
+This documentation shows one quick example how to setup and run this repository locally, including the setup of the RESTful services to be served locally at [http://localhost:8888/rest/](http://localhost:8888/rest/) with Lucee Express for development.  
 
 **1. Step:** Download a **Lucee Express Release** version at [https://download.lucee.org](https://download.lucee.org) and unpack it, run and see if it's serving content at [http://localhost:8888](http://localhost:8888). For more information about downloading and running **Lucee Express (ZIP)** please visit [https://docs.lucee.org/guides/installing-lucee/download-and-install.html](https://docs.lucee.org/guides/installing-lucee/download-and-install.html).
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The repository mainly consists of the following directories:
 
 ## Installation for local development
 
-This documentation shows a quick example how to setup and run the repository locally. including the RESTful services at [http://localhost:8888](http://localhost:8888) with Lucee Express.  
+This documentation shows a quick example how to setup and run the repository locally. including the setup of the RESTful services for development with [http://localhost:8888](http://localhost:8888) with Lucee Express.  
 
 **1. Step:** Download a Lucee Express Release version at [https://download.lucee.org](https://download.lucee.org) and unpack it, run it and see if it's serving content at [http://localhost:8888](http://localhost:8888). For more information about how to download and run **Lucee Express (ZIP)** please visit [https://docs.lucee.org/guides/installing-lucee/download-and-install](https://docs.lucee.org/guides/installing-lucee/download-and-install).html.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Save that file to `C:\path-to-your-lucee-express\conf\Catalina\localhost\ROOT.xm
 
 **5. Step:** The lucee-data-provider requires distribution files to be read and create content. Thus, you need to download at least one distribution file (e.g. lucee.jar) manually of each category "Release", "RC", "Snapshot", "Beta" from [https://download.lucee.org](https://download.lucee.org). The same applies to **Extension** distribution files. Download them and save them for example to a directory named `C:\lucee-downloads\`.
 
-**6. Step:** Next step is to feed the web application with the correct configuration values to serve the content from your local development machine (e.g. using the RESTful service of your localhost) instead of the Lucees online distribution and RESTful services sites. This can be easily done within Lucee Express by setting **environment variables** that will override the default settings. The **environment variables**  can be set as follows:
+**6. Step:** Next step is to feed the web application with the correct configuration values to serve the content from your local development machine (e.g. using the RESTful service of your localhost instead of the Lucees online distribution and RESTful services sites). This can be easily done within Lucee Express by setting **environment variables** that will override the default settings. The **environment variables**  can be set as follows:
 
 For **Lucee Express** in *Windows*, create a file named *setenv.bat*  with the following content:
 
@@ -82,6 +82,14 @@ Save that file to `\path-to-your-lucee-express\bin\setenv.sh` and restart **Luce
 
 Of course, the environment variables can be set in many other ways, e.g. from within your OS (as an alternative to setenv.bat/setenv.sh)
 
-**7. Step:**: Set up and add the RestFull Services by running the *updateRestMappings.cfm* template located at [http://localhost:8888/download/updateRestMappings.cfm](http://localhost:8888/download/updateRestMappings.cfm). This template is physically loacted at `/download/updateRestMappings.cfm` and contains the [restInitApplication() function](https://docs.lucee.org/reference/functions/restinitapplication.html) to add RESTful mappings to serve restpaths "extension" and "update" restpaths to your localhost context. Note that you MUST provide your Lucee Web Administration password to run restInitApplication().
+**7. Step:** Set up and add the RestFull Services by running the *updateRestMappings.cfm* template located at [http://localhost:8888/download/updateRestMappings.cfm](http://localhost:8888/download/updateRestMappings.cfm). This template is physically loacted at `/download/updateRestMappings.cfm` and contains the [restInitApplication() function](https://docs.lucee.org/reference/functions/restinitapplication.html) to add RESTful mappings to serve restpaths "extension" and "update" restpaths to your localhost context. Note that you MUST provide your Lucee Web Administration password to run restInitApplication().
 
 To make sure the RESTful mappings are correclty being served, log into your *Lucee Web Administrator* -&gt; *Archives & Resources* -&gt; *Rest*, and activate *"List services"*. Then navigate to [http://localhost:8888/rest/](http://localhost:8888/rest/) to see them listed.
+
+**8. Step:** Open the **download web application** at  [http://localhost:8888/download/](http://localhost:8888/download/)
+
+**IMPORTANT NOTE**: 
+
+- When working with this repository locally, some changes made to the components serving RESTful services (e.g. UpdateProvider.cfc or ExtensionProvider.cfc ) may need to have the mappings updated for the changes to take effect. For this purpose simply run the *updateRestMappings.cfm* by calling it at [http://localhost:8888/download/updateRestMappings.cfm](http://localhost:8888/download/updateRestMappings.cfm).
+
+- To update/refresh/reset the download site, run [http://localhost:8888/download/?reset](http://localhost:8888/download/?reset).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The repository mainly consists of the following directories:
 
 This documentation shows a quick example how to setup and run the repository locally. including the setup of the RESTful services for development with [http://localhost:8888](http://localhost:8888) with Lucee Express.  
 
-**1. Step:** Download a Lucee Express Release version at [https://download.lucee.org](https://download.lucee.org) and unpack it, run it and see if it's serving content at [http://localhost:8888](http://localhost:8888). For more information about how to download and run **Lucee Express (ZIP)** please visit [https://docs.lucee.org/guides/installing-lucee/download-and-install](https://docs.lucee.org/guides/installing-lucee/download-and-install).html.
+**1. Step:** Download a Lucee Express Release version at [https://download.lucee.org](https://download.lucee.org) and unpack it, run it and see if it's serving content at [http://localhost:8888](http://localhost:8888). For more information about downloading and running **Lucee Express (ZIP)** please visit [https://docs.lucee.org/guides/installing-lucee/download-and-install](https://docs.lucee.org/guides/installing-lucee/download-and-install.html).
 
 **2. Step:** Create a local directory to serve as workspace for your development, e.g. `C:\workspace-lucee-data-provider\`
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Home of Lucee Download Web Application and its RestServices dependencies
 
-This repository contains the web application and its REST Service dependencies to provide it's distribution files.
+This repository contains the web application and the REST Service dependencies to provide the main distribution files, such as installers, snapshots, servlet containers, extensions and more.
 
-The repository mainly contains the following directories:
+The repository mainly consists of the following directories:
 
-**/download**: for hosting [http://stable.lucee.org/](http://stable.lucee.org/) and [https://downloads.lucee.org](https://downloads.lucee.org)
-**/update**: serves the update provider as RESTful service hosted at [http://update.lucee.org](http://update.lucee.org)
-**/extension**: serves the extension provider as RESTful service hosted at [http://extension.lucee.org](http://extension.lucee.org)
+- **/download**: for hosting [http://stable.lucee.org/](http://stable.lucee.org/) and [https://downloads.lucee.org](https://downloads.lucee.org)
+- **/update**: serves the update provider as RESTful service hosted at [http://update.lucee.org](http://update.lucee.org)
+- **/extension**: serves the extension provider as RESTful service hosted at [http://extension.lucee.org](http://extension.lucee.org)
 
 ## Installation for local development
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ set "LUCEE_DATA_PROVIDER_EXTENSION_PROVIDER_SNAPSHOT=http://localhost:8888/rest/
 
 REM set "LUCEE_DATA_PROVIDER_S3URL=https://s3-eu-west-1.amazonaws.com/lucee-downloads/"
 
+REM exit from setenv.bat
+exit /b 0
+
 ```
 
 Save that file to `C:\path-to-your-lucee-express\bin\setenv.bat` and restart **Lucee Express**.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,87 @@
-# lucee-data-provider
+# Home of Lucee Download Web Application and its RestServices dependencies
 
-Home of http://stable.lucee.org/download/
+This repository contains the web application and its REST Service dependencies to provide it's distribution files.
+
+The repository mainly contains the following directories:
+
+**/download**: for hosting [http://stable.lucee.org/](http://stable.lucee.org/) and [https://downloads.lucee.org](https://downloads.lucee.org)
+**/update**: serves the update provider as RESTful service hosted at [http://update.lucee.org](http://update.lucee.org)
+**/extension**: serves the extension provider as RESTful service hosted at [http://extension.lucee.org](http://extension.lucee.org)
+
+## Installation for local development
+
+This documentation shows a quick example how to setup and run the repository locally. including the RESTful services at [http://localhost:8888](http://localhost:8888) with Lucee Express.  
+
+**1. Step:** Download a Lucee Express Release version at [https://download.lucee.org](https://download.lucee.org) and unpack it, run it and see if it's serving content at [http://localhost:8888](http://localhost:8888). For more information about how to download and run **Lucee Express (ZIP)** please visit [https://docs.lucee.org/guides/installing-lucee/download-and-install](https://docs.lucee.org/guides/installing-lucee/download-and-install).html.
+
+**2. Step:** Create a local directory to serve as workspace for your development, e.g. `C:\workspace-lucee-data-provider\`
+
+**3. Step:** Go to the Github repository site at [https://github.com/lucee/lucee-data-provider](https://github.com/lucee/lucee-data-provider) and download the master branch by clicking the **Code**-button and **Download ZIP**. Unpack it to your `C:\workspace-lucee-data-provider\`, so that the content of the downloaded and unpacked repository will be located at `C:\workspace-lucee-data-provider\lucee-data-provider-master\`.
+
+**4. Step:** Configure **"Lucee Express"** by creating a file named *ROOT.xml* pointing to your local repository with the following content:
+
+```xml
+<?xml version='1.0' encoding='utf-8'?>
+<Context docBase="C:\workspace-lucee-data-provider\lucee-data-provider-master\">
+  <WatchedResource>WEB-INF/web.xml</WatchedResource>
+  <JarScanner scanClassPath="false" />
+</Context>
+```
+
+Save that file to `C:\path-to-your-lucee-express\conf\Catalina\localhost\ROOT.xml` and restart **Lucee Express**.
+
+**5. Step:** The lucee-data-provider requires distribution files to be read and create content. Thus, you need to download at least one distribution file (e.g. lucee.jar) manually of each category "Release", "RC", "Snapshot", "Beta" from [https://download.lucee.org](https://download.lucee.org). The same applies to **Extension** distribution files. Download them and save them for example to a directory named `C:\lucee-downloads\`.
+
+**6. Step:** Next step is to feed the web application with the correct configuration values to serve the content from your local development machine (e.g. using the RESTful service of your localhost) instead of the Lucees online distribution and RESTful services sites. This can be easily done within Lucee Express by setting **environment variables** that will override the default settings. The **environment variables**  can be set as follows:
+
+For **Lucee Express** in *Windows*, create a file named *setenv.bat*  with the following content:
+
+```
+REM #### TOMCAT WINDOWS: SETS ENV VARS in setenv.bat with the following enviroment varibales.
+REM #### This won't work when running Tomcat as service. In this case you can alternatively add the 
+REM #### Environment Variables by running the following Tomcat service update command in a terminal window: 
+REM #### path-to-lucee-installation\tomcat\bin\tomcat9.exe //US//NameOfYourTomcatService --Environment=key1=value1;key2=...
+
+REM S3Root need to point to a directory containing distribution files
+set "LUCEE_DATA_PROVIDER_S3ROOT=C:\lucee-downloads\"
+set "LUCEE_DATA_PROVIDER_UPDATE_PROVIDER_BASEURL=http://localhost:8888/rest/update/provider/"
+set "LUCEE_DATA_PROVIDER_UPDATE_PROVIDER=http://localhost:8888/rest/update/provider/list?extended=true"
+set "LUCEE_DATA_PROVIDER_EXTENSION_PROVIDER=http://localhost:8888/rest/extension/provider/info?withLogo=true&type=all"
+set "LUCEE_DATA_PROVIDER_EXTENSION_DOWNLOAD=http://localhost:8888/rest/extension/provider/{type}/{id}"
+set "LUCEE_DATA_PROVIDER_EXTENSION_PROVIDER_RELEASE=http://localhost:8888/rest/extension/provider/info?withLogo=true&type=release"
+set "LUCEE_DATA_PROVIDER_EXTENSION_PROVIDER_ABC=http://localhost:8888/rest/extension/provider/info?withLogo=true&type=abc"
+set "LUCEE_DATA_PROVIDER_EXTENSION_PROVIDER_SNAPSHOT=http://localhost:8888/rest/extension/provider/info?withLogo=true&type=snapshot"
+
+REM set "LUCEE_DATA_PROVIDER_S3URL=https://s3-eu-west-1.amazonaws.com/lucee-downloads/"
+
+```
+
+Save that file to `C:\path-to-your-lucee-express\bin\setenv.bat` and restart **Lucee Express**.
+
+For **Lucee Express** in *Linux*, create a file named *setenv.sh*  with the following content:
+
+```
+
+# TOMCAT LINUX: SETS ENV VARS in setenv.sh with the following enviroment varibales:
+
+# S3Root pointing to distribution files
+LUCEE_DATA_PROVIDER_S3ROOT=\var\www\lucee-downloads\
+LUCEE_DATA_PROVIDER_UPDATE_PROVIDER_BASEURL=http://localhost:8888/rest/update/provider/
+LUCEE_DATA_PROVIDER_UPDATE_PROVIDER=http://localhost:8888//rest/update/provider/list?extended=true
+LUCEE_DATA_PROVIDER_EXTENSION_PROVIDER=http://localhost:8888/rest/extension/provider/info?withLogo=true&type=all
+LUCEE_DATA_PROVIDER_EXTENSION_DOWNLOAD=http://localhost:8888/rest/extension/provider/{type}/{id}
+LUCEE_DATA_PROVIDER_EXTENSION_PROVIDER_RELEASE=http://localhost:8888/rest/extension/provider/info?withLogo=true&type=release
+LUCEE_DATA_PROVIDER_EXTENSION_PROVIDER_ABC=http://localhost:8888/rest/extension/provider/info?withLogo=true&type=abc
+LUCEE_DATA_PROVIDER_EXTENSION_PROVIDER_SNAPSHOT=http://localhost:8888/rest/extension/provider/info?withLogo=true&type=snapshot
+
+#LUCEE_DATA_PROVIDER_S3URL=https://s3-eu-west-1.amazonaws.com/lucee-downloads/
+
+```
+
+Save that file to `\path-to-your-lucee-express\bin\setenv.sh` and restart **Lucee Express**. This file may need execution permission to run on Linux.
+
+Of course, the environment variables can be set in many other ways, e.g. from within your OS (as an alternative to setenv.bat/setenv.sh)
+
+**7. Step:**: Set up and add the RestFull Services by running the *updateRestMappings.cfm* template located at [http://localhost:8888/download/updateRestMappings.cfm](http://localhost:8888/download/updateRestMappings.cfm). This template is physically loacted at `/download/updateRestMappings.cfm` and contains the [restInitApplication() function](https://docs.lucee.org/reference/functions/restinitapplication.html) to add RESTful mappings to serve restpaths "extension" and "update" restpaths to your localhost context. Note that you MUST provide your Lucee Web Administration password to run restInitApplication().
+
+To make sure the RESTful mappings are correclty being served, log into your *Lucee Web Administrator* -&gt; *Archives & Resources* -&gt; *Rest*, and activate *"List services"*. Then navigate to [http://localhost:8888/rest/](http://localhost:8888/rest/) to see them listed.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The repository mainly consists of the following directories:
 
 ## Installation for local development
 
-This documentation shows one quick example how to setup and run this repository locally. including the setup of the RESTful services served locally at [http://localhost:8888](http://localhost:8888) with Lucee Express for development.  
+This documentation shows one quick example how to setup and run this repository locally, including the setup of the RESTful services to be served locally at [http://localhost:8888](http://localhost:8888) with Lucee Express for development.  
 
 **1. Step:** Download a **Lucee Express Release** version at [https://download.lucee.org](https://download.lucee.org) and unpack it, run and see if it's serving content at [http://localhost:8888](http://localhost:8888). For more information about downloading and running **Lucee Express (ZIP)** please visit [https://docs.lucee.org/guides/installing-lucee/download-and-install.html](https://docs.lucee.org/guides/installing-lucee/download-and-install.html).
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Save that file to `\path-to-your-lucee-express\bin\setenv.sh` and restart **Luce
 
 Of course, the environment variables can be set in many other ways, e.g. from within your OS (as an alternative to setenv.bat/setenv.sh)
 
-**7. Step:** Set up and add the RESTful Services by running the *updateRestMappings.cfm* template located at [http://localhost:8888/download/updateRestMappings.cfm](http://localhost:8888/download/updateRestMappings.cfm). This template is physically loacted at `/download/updateRestMappings.cfm` and contains the [restInitApplication() function](https://docs.lucee.org/reference/functions/restinitapplication.html) to add RESTful mappings to serve restpaths "extension" and "update" restpaths to your localhost context. Note that you MUST provide your Lucee Web Administration password to run restInitApplication().
+**7. Step:** Set up and add the RESTful Services by running the *updateRestMappings.cfm* template located at [http://localhost:8888/download/updateRestMappings.cfm](http://localhost:8888/download/updateRestMappings.cfm). This template is physically loacted at `/download/updateRestMappings.cfm` and contains the [restInitApplication() function](https://docs.lucee.org/reference/functions/restinitapplication.html) to add RESTful mappings to serve restpaths "extension" and "update" restpaths to your localhost context. Note that you MUST provide your Lucee Web Administration password to run *restInitApplication()*.
 
 To make sure the RESTful mappings are correclty being served, log into your *Lucee Web Administrator* -&gt; *Archives & Resources* -&gt; *Rest*, and activate *"List services"*. Then navigate to [http://localhost:8888/rest/](http://localhost:8888/rest/) to see them listed.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Save that file to `\path-to-your-lucee-express\bin\setenv.sh` and restart **Luce
 
 Of course, the environment variables can be set in many other ways, e.g. from within your OS (as an alternative to setenv.bat/setenv.sh)
 
-**7. Step:** Set up and add the RestFull Services by running the *updateRestMappings.cfm* template located at [http://localhost:8888/download/updateRestMappings.cfm](http://localhost:8888/download/updateRestMappings.cfm). This template is physically loacted at `/download/updateRestMappings.cfm` and contains the [restInitApplication() function](https://docs.lucee.org/reference/functions/restinitapplication.html) to add RESTful mappings to serve restpaths "extension" and "update" restpaths to your localhost context. Note that you MUST provide your Lucee Web Administration password to run restInitApplication().
+**7. Step:** Set up and add the RESTful Services by running the *updateRestMappings.cfm* template located at [http://localhost:8888/download/updateRestMappings.cfm](http://localhost:8888/download/updateRestMappings.cfm). This template is physically loacted at `/download/updateRestMappings.cfm` and contains the [restInitApplication() function](https://docs.lucee.org/reference/functions/restinitapplication.html) to add RESTful mappings to serve restpaths "extension" and "update" restpaths to your localhost context. Note that you MUST provide your Lucee Web Administration password to run restInitApplication().
 
 To make sure the RESTful mappings are correclty being served, log into your *Lucee Web Administrator* -&gt; *Archives & Resources* -&gt; *Rest*, and activate *"List services"*. Then navigate to [http://localhost:8888/rest/](http://localhost:8888/rest/) to see them listed.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Home of Lucee Download Web Application and its RestServices dependencies
+# Home Of Lucee Download Web Application and its RESTful Service Dependencies
 
-This repository contains the web application and the REST Service dependencies to provide the main distribution files, such as installers, snapshots, servlet containers, extensions and more.
+This repository contains the web application and the RESTful service dependencies that provide the main distribution files, such as installers, snapshots, servlet containers, beta, extensions and more.
 
 The repository mainly consists of the following directories:
 
@@ -10,15 +10,15 @@ The repository mainly consists of the following directories:
 
 ## Installation for local development
 
-This documentation shows a quick example how to setup and run the repository locally. including the setup of the RESTful services for development with [http://localhost:8888](http://localhost:8888) with Lucee Express.  
+This documentation shows one quick example how to setup and run this repository locally. including the setup of the RESTful services served locally at [http://localhost:8888](http://localhost:8888) with Lucee Express for development.  
 
-**1. Step:** Download a Lucee Express Release version at [https://download.lucee.org](https://download.lucee.org) and unpack it, run it and see if it's serving content at [http://localhost:8888](http://localhost:8888). For more information about downloading and running **Lucee Express (ZIP)** please visit [https://docs.lucee.org/guides/installing-lucee/download-and-install.html](https://docs.lucee.org/guides/installing-lucee/download-and-install.html).
+**1. Step:** Download a **Lucee Express Release** version at [https://download.lucee.org](https://download.lucee.org) and unpack it, run and see if it's serving content at [http://localhost:8888](http://localhost:8888). For more information about downloading and running **Lucee Express (ZIP)** please visit [https://docs.lucee.org/guides/installing-lucee/download-and-install.html](https://docs.lucee.org/guides/installing-lucee/download-and-install.html).
 
-**2. Step:** Create a local directory to serve as workspace for your development, e.g. `C:\workspace-lucee-data-provider\`
+**2. Step:** Create a local directory to serve as development workspace. We will use e.g. `C:\workspace-lucee-data-provider\`.
 
-**3. Step:** Go to the Github repository site at [https://github.com/lucee/lucee-data-provider](https://github.com/lucee/lucee-data-provider) and download the master branch by clicking the **Code**-button and **Download ZIP**. Unpack it to your `C:\workspace-lucee-data-provider\`, so that the content of the downloaded and unpacked repository will be located at `C:\workspace-lucee-data-provider\lucee-data-provider-master\`.
+**3. Step:** Go to the Github repository site at [https://github.com/lucee/lucee-data-provider](https://github.com/lucee/lucee-data-provider) and download the master branch by clicking the **Code**-button and **Download ZIP**. Unpack it to your workspace from 2.Step at `C:\workspace-lucee-data-provider\`, so that the content of the downloaded and unpacked repository will be located at `C:\workspace-lucee-data-provider\lucee-data-provider-master\`.
 
-**4. Step:** Configure **"Lucee Express"** by creating a file named *ROOT.xml* pointing to your local repository with the following content:
+**4. Step:** Configure **"Lucee Express"** by creating a file named *ROOT.xml* at `C:\path-to-your-lucee-express\conf\Catalina\localhost\ROOT.xml`, containing the docBase attribute pointing to your local repository of your workspace as follows:
 
 ```xml
 <?xml version='1.0' encoding='utf-8'?>
@@ -28,11 +28,11 @@ This documentation shows a quick example how to setup and run the repository loc
 </Context>
 ```
 
-Save that file to `C:\path-to-your-lucee-express\conf\Catalina\localhost\ROOT.xml` and restart **Lucee Express**.
+After saving the file to `C:\path-to-your-lucee-express\conf\Catalina\localhost\ROOT.xml` restart **Lucee Express**.
 
-**5. Step:** The lucee-data-provider requires distribution files to be read and create content. Thus, you need to download at least one distribution file (e.g. lucee.jar) manually of each category "Release", "RC", "Snapshot", "Beta" from [https://download.lucee.org](https://download.lucee.org). The same applies to **Extension** distribution files. Download them and save them for example to a directory named `C:\lucee-downloads\`.
+**5. Step:** The **lucee-data-provider** requires distribution files to be read and create content dynamically. Thus, you need to download at least one distribution file (e.g. lucee.jar) manually of each category "Release", "RC", "Snapshot", "Beta" from [https://download.lucee.org](https://download.lucee.org) to a local directory (we will use e.g. `C:\lucee-downloads\`). The same dynamic content creation applies to Lucee **Extension** distribution files. Download some *Extension* to `C:\lucee-downloads\` also, just to provide content.
 
-**6. Step:** Next step is to feed the web application with the correct configuration values to serve the content from your local development machine (e.g. using the RESTful service of your localhost instead of the Lucees online distribution and RESTful services sites). This can be easily done within Lucee Express by setting **environment variables** that will override the default settings. The **environment variables**  can be set as follows:
+**6. Step:** Next step is to feed the web application with the correct configuration values to serve the content from your local development machine (e.g. using the RESTful service of your localhost instead of the Lucees online distribution and RESTful services sites). This can be easily done within *Lucee Express* by setting **environment variables**. These will override the default settings to setup a local development context. The **environment variables** can be set as follows:
 
 For **Lucee Express** in *Windows*, create a file named *setenv.bat*  with the following content:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The repository mainly consists of the following directories:
 
 This documentation shows a quick example how to setup and run the repository locally. including the setup of the RESTful services for development with [http://localhost:8888](http://localhost:8888) with Lucee Express.  
 
-**1. Step:** Download a Lucee Express Release version at [https://download.lucee.org](https://download.lucee.org) and unpack it, run it and see if it's serving content at [http://localhost:8888](http://localhost:8888). For more information about downloading and running **Lucee Express (ZIP)** please visit [https://docs.lucee.org/guides/installing-lucee/download-and-install](https://docs.lucee.org/guides/installing-lucee/download-and-install.html).
+**1. Step:** Download a Lucee Express Release version at [https://download.lucee.org](https://download.lucee.org) and unpack it, run it and see if it's serving content at [http://localhost:8888](http://localhost:8888). For more information about downloading and running **Lucee Express (ZIP)** please visit [https://docs.lucee.org/guides/installing-lucee/download-and-install.html](https://docs.lucee.org/guides/installing-lucee/download-and-install.html).
 
 **2. Step:** Create a local directory to serve as workspace for your development, e.g. `C:\workspace-lucee-data-provider\`
 
@@ -90,6 +90,6 @@ To make sure the RESTful mappings are correclty being served, log into your *Luc
 
 **IMPORTANT NOTE**: 
 
-- When working with this repository locally, some changes made to the components serving RESTful services (e.g. UpdateProvider.cfc or ExtensionProvider.cfc ) may need to have the mappings updated for the changes to take effect. For this purpose simply run the *updateRestMappings.cfm* by calling it at [http://localhost:8888/download/updateRestMappings.cfm](http://localhost:8888/download/updateRestMappings.cfm).
+- When working with this repository locally, some changes made to the components serving RESTful services (e.g. UpdateProvider.cfc or ExtensionProvider.cfc ) may need to have the mappings updated for the changes to take effect. For this purpose simply run the [updateRestMappings.cfm](https://github.com/andreasRu/lucee-data-provider/blob/patch-andreasru/download/updateRestMappings.cfm) by calling it at [http://localhost:8888/download/updateRestMappings.cfm](http://localhost:8888/download/updateRestMappings.cfm).
 
 - To update/refresh/reset the download site, run [http://localhost:8888/download/?reset](http://localhost:8888/download/?reset).

--- a/download/functions.cfm
+++ b/download/functions.cfm
@@ -21,12 +21,12 @@ _url={
 };
 
 
-
-UPDATE_PROVIDER="http://update.lucee.org/rest/update/provider/list?extended=true";
-EXTENSION_PROVIDER="http://extension.lucee.org/rest/extension/provider/info?withLogo=true&type=release";
-EXTENSION_PROVIDER_ABC="http://extension.lucee.org/rest/extension/provider/info?withLogo=true&type=abc";
-EXTENSION_PROVIDER_SNAPSHOT="http://extension.lucee.org/rest/extension/provider/info?withLogo=true&type=snapshot";
-EXTENSION_DOWNLOAD="https://extension.lucee.org/rest/extension/provider/{type}/{id}";
+// Populate configuration with env variables or fallback to default settings
+UPDATE_PROVIDER             = server.system.environment["LUCEE_DATA_PROVIDER_UPDATE_PROVIDER"] ?: "http://update.lucee.org/rest/update/provider/list?extended=true";
+EXTENSION_PROVIDER_RELEASE  = server.system.environment["LUCEE_DATA_PROVIDER_EXTENSION_PROVIDER_RELEASE"] ?: "http://extension.lucee.org/rest/extension/provider/info?withLogo=true&type=release";
+EXTENSION_PROVIDER_ABC      = server.system.environment["LUCEE_DATA_PROVIDER_EXTENSION_PROVIDER_ABC"] ?: "http://extension.lucee.org/rest/extension/provider/info?withLogo=true&type=abc";
+EXTENSION_PROVIDER_SNAPSHOT = server.system.environment["LUCEE_DATA_PROVIDER_EXTENSION_PROVIDER_SNAPSHOT"] ?: "http://extension.lucee.org/rest/extension/provider/info?withLogo=true&type=snapshot";
+EXTENSION_DOWNLOAD          = server.system.environment["LUCEE_DATA_PROVIDER_EXTENSION_DOWNLOAD"] ?: "https://extension.lucee.org/rest/extension/provider/{type}/{id}";
 
 // texts
 
@@ -299,7 +299,7 @@ lang.installer.lin32="Linux (32b)";
 				
 				http url=UPDATE_PROVIDER result="local.res";
 				var arr=deserializeJSON(res.fileContent);
-				var qry=queryNew('id,groupId,artifactId,version,vs,type,jarDate,src,s3War,s3Express,s3Light,s3Core,state,t');
+                var qry=queryNew('id,groupId,artifactId,version,vs,type,jarDate,src,s3War,s3Express,s3Light,s3Core,state,t');
 				for(var r=arrayLen(arr);r>=1;r--) {
 					row=arr[r];
 					
@@ -435,7 +435,7 @@ lang.installer.lin32="Linux (32b)";
 	function _getExtensions(required string type) localmode=true {
 		if(arguments.type=="snapshot") local.ep=EXTENSION_PROVIDER_SNAPSHOT;
 		else if(arguments.type=="abc") local.ep=EXTENSION_PROVIDER_ABC;
-		else local.ep=EXTENSION_PROVIDER;
+		else local.ep=EXTENSION_PROVIDER_RELEASE;
 		//dump(type&"-"&ep);abort;
 
 		http url=ep result="http";

--- a/download/updateRestMappings.cfm
+++ b/download/updateRestMappings.cfm
@@ -6,7 +6,7 @@
     ***/
 
     if( cgi.SERVER_NAME=="localhost") {
-        basePath=getDirectoryFromPath( getTemplatePath() );
+        basePath=getDirectoryFromPath(  GetBaseTemplatePath() );
         restInitApplication( 
             dirPath= basePath & "/../extension", 
             serviceMapping="extension", 

--- a/download/updateRestMappings.cfm
+++ b/download/updateRestMappings.cfm
@@ -1,6 +1,6 @@
 <cfscript>
     /***
-    * Run this templage to add/update Restful services from within your web-context (e.g. http://localhost:8888/download/updateRestMappings.cfm ) 
+    * Run this template to add/update Restful services from within your web-context (e.g. http://localhost:8888/download/updateRestMappings.cfm ) 
     * that will add/update the Rest Service. After running, confirm with http://localhost:8888/rest (to activate rest listings go
     * to: Lucee Administrator -> Archives & Resources -> Rest, and activate "List services")
     ***/
@@ -18,6 +18,8 @@
             serviceMapping="update", 
             password="myDevWebAdminPassword"
         );
+
+        echo("REST mappings updated for localhost");
     }
-    echo("REST mappings updated");
+    
 </cfscript>

--- a/download/updateRestMappings.cfm
+++ b/download/updateRestMappings.cfm
@@ -1,0 +1,23 @@
+<cfscript>
+    /***
+    * Run this templage to add/update Restful services from within your web-context (e.g. http://localhost:8888/download/updateRestMappings.cfm ) 
+    * that will add/update the Rest Service. After running, confirm with http://localhost:8888/rest (to activate rest listings go
+    * to: Lucee Administrator -> Archives & Resources -> Rest, and activate "List services")
+    ***/
+
+    if( cgi.SERVER_NAME=="localhost") {
+        basePath=getDirectoryFromPath( getTemplatePath() );
+        restInitApplication( 
+            dirPath= basePath & "/../extension", 
+            serviceMapping="extension", 
+            password="myDevWebAdminPassword"
+        );
+
+        restInitApplication( 
+            dirPath= basePath & "/../update", 
+            serviceMapping="update", 
+            password="myDevWebAdminPassword"
+        );
+    }
+    echo("REST mappings updated");
+</cfscript>

--- a/extension/ExtensionProvider.cfc
+++ b/extension/ExtensionProvider.cfc
@@ -12,7 +12,7 @@
 
 
 	// new
-	variables.s3Root=request.s3Root;//"s3:///lucee-downloads/";
+	variables.s3Root= server.system.environment["LUCEE_DATA_PROVIDER_S3ROOT"] ?: "s3:///lucee-downloads/";
 	variables.cdnURL="https://ext.lucee.org/";
 	variables.current=getDirectoryFromPath(getCurrentTemplatePath());
 	

--- a/update/Application.cfc
+++ b/update/Application.cfc
@@ -1,4 +1,4 @@
 component {
-	request.s3Root="s3:///lucee-downloads/";
-	request.s3URL="https://s3-eu-west-1.amazonaws.com/lucee-downloads/";
+    request.s3Root  = server.system.environment["LUCEE_DATA_PROVIDER_S3ROOT"] ?: "s3:///lucee-downloads/";
+	request.s3URL   = server.system.environment["LUCEE_DATA_PROVIDER_S3URL"] ?: "https://s3-eu-west-1.amazonaws.com/lucee-downloads/";
 }

--- a/update/UpdateProvider.cfc
+++ b/update/UpdateProvider.cfc
@@ -1,9 +1,8 @@
 ﻿component restpath="/provider"  rest="true" {
 
-
-	variables.s3Root=request.s3Root;//"s3:///lucee-downloads/";
-	variables.s3URL="https://s3-eu-west-1.amazonaws.com/lucee-downloads/";
-	variables.cdnURL="https://cdn.lucee.org/";
+    request.s3Root  = server.system.environment["LUCEE_DATA_PROVIDER_S3ROOT"] ?: "s3:///lucee-downloads/";
+	request.s3URL   = server.system.environment["LUCEE_DATA_PROVIDER_S3URL"] ?: "https://s3-eu-west-1.amazonaws.com/lucee-downloads/";
+    variables.cdnURL="https://cdn.lucee.org/";
 
 	jiraDomain="luceeserver.atlassian.net";
 	
@@ -38,6 +37,11 @@
 	variables.current=getDirectoryFromPath(getCurrentTemplatePath());
 	variables.artDirectory=variables.current&"artifacts/";
 	variables.extDirectory="/var/www/sites/extension/extension5/extensions/"; // TODO make more dynamic
+
+    remote struct function showVars()
+    httpmethod="GET" restpath="vars"{
+        return {"variables": variables};
+    }
 
 		/**
 	* if there is a update the function is returning a struct like this:

--- a/update/UpdateProvider.cfc
+++ b/update/UpdateProvider.cfc
@@ -1,6 +1,6 @@
 ﻿component restpath="/provider"  rest="true" {
 
-    request.s3Root  = server.system.environment["LUCEE_DATA_PROVIDER_S3ROOT"] ?: request.s3Root; "s3:///lucee-downloads/";
+    request.s3Root  = server.system.environment["LUCEE_DATA_PROVIDER_S3ROOT"] ?: "s3:///lucee-downloads/";
 	request.s3URL   = server.system.environment["LUCEE_DATA_PROVIDER_S3URL"] ?: "https://s3-eu-west-1.amazonaws.com/lucee-downloads/";
     variables.cdnURL="https://cdn.lucee.org/";
 

--- a/update/UpdateProvider.cfc
+++ b/update/UpdateProvider.cfc
@@ -1,6 +1,6 @@
 ﻿component restpath="/provider"  rest="true" {
 
-    request.s3Root  = server.system.environment["LUCEE_DATA_PROVIDER_S3ROOT"] ?: "s3:///lucee-downloads/";
+    request.s3Root  = server.system.environment["LUCEE_DATA_PROVIDER_S3ROOT"] ?: request.s3Root; "s3:///lucee-downloads/";
 	request.s3URL   = server.system.environment["LUCEE_DATA_PROVIDER_S3URL"] ?: "https://s3-eu-west-1.amazonaws.com/lucee-downloads/";
     variables.cdnURL="https://cdn.lucee.org/";
 


### PR DESCRIPTION
This PR:
- adds env variables with fallback to the default values, that enables easier switching for local development with Lucee Express. That should motivate external contributors to enhance the code.
- adds a template for quick setup/update of the RESTful service mappings in local development with a simple call.
- adds an installation and setup guide for running the dev environment

That should help contributors setting up a deveopment fast.

Note: I did this with my best effort to not break existing code, but I did minor refactoring. I wasn't able to test it in a proper configuration as of production because I don't know all the internal web server and servlet container production settings. 