### PR TITLE
enable sentry logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ target/*
 update/cache/versions.json
 update/WEB-INF
 .env
+/root/debug.cfm
+/download/debug.cfm
+update/log-maven-download.log
+update/missing-bundles.txt

--- a/compose.yaml
+++ b/compose.yaml
@@ -30,6 +30,8 @@ services:
       - VIRTUAL_HOST=download.lucee.local
       - S3_DOWNLOAD_ACCESS_KEY_ID=${S3_DOWNLOAD_ACCESS_KEY_ID:-xxxxxx}
       - S3_DOWNLOAD_SECRET_KEY=${S3_DOWNLOAD_SECRET_KEY:-xxxxxx}
+      - SENTRY_ENV=${SENTRY_ENV:-xxxxxx}
+      - SENTRY_DSN=${SENTRY_DSN:-xxxxxx}
 
   update:
     build:
@@ -48,3 +50,5 @@ services:
       - S3_EXTENSION_ACCESS_KEY_ID=${S3_EXTENSION_ACCESS_KEY_ID:-xxxxxx}
       - S3_DOWNLOAD_SECRET_KEY=${S3_DOWNLOAD_SECRET_KEY:-xxxxxx}
       - S3_DOWNLOAD_ACCESS_KEY_ID=${S3_DOWNLOAD_ACCESS_KEY_ID:-xxxxxx}
+      - SENTRY_ENV=${SENTRY_ENV:-xxxxxx}
+      - SENTRY_DSN=${SENTRY_DSN:-xxxxxx}

--- a/compose.yaml
+++ b/compose.yaml
@@ -30,8 +30,8 @@ services:
       - VIRTUAL_HOST=download.lucee.local
       - S3_DOWNLOAD_ACCESS_KEY_ID=${S3_DOWNLOAD_ACCESS_KEY_ID:-xxxxxx}
       - S3_DOWNLOAD_SECRET_KEY=${S3_DOWNLOAD_SECRET_KEY:-xxxxxx}
-      - SENTRY_ENV=${SENTRY_ENV:-xxxxxx}
-      - SENTRY_DSN=${SENTRY_DSN:-xxxxxx}
+      - SENTRY_ENV=${SENTRY_ENV:-""}
+      - SENTRY_DSN=${SENTRY_DSN:-""}
 
   update:
     build:
@@ -50,5 +50,5 @@ services:
       - S3_EXTENSION_ACCESS_KEY_ID=${S3_EXTENSION_ACCESS_KEY_ID:-xxxxxx}
       - S3_DOWNLOAD_SECRET_KEY=${S3_DOWNLOAD_SECRET_KEY:-xxxxxx}
       - S3_DOWNLOAD_ACCESS_KEY_ID=${S3_DOWNLOAD_ACCESS_KEY_ID:-xxxxxx}
-      - SENTRY_ENV=${SENTRY_ENV:-xxxxxx}
-      - SENTRY_DSN=${SENTRY_DSN:-xxxxxx}
+      - SENTRY_ENV=${SENTRY_ENV:-""}
+      - SENTRY_DSN=${SENTRY_DSN:-""}

--- a/devops/.CFconfig-download.json5
+++ b/devops/.CFconfig-download.json5
@@ -157,12 +157,6 @@
             "appenderBundleVersion": "5.5.2.15",
             "layoutClass": "lucee.commons.io.log.log4j2.layout.ClassicLayout",
             "layoutArguments": ""
-            /*
-            "appender": "resource",
-            "appenderArguments": "path:{lucee-config}/logs/application.log",
-            "level": "info",
-            "layout": "classic"
-            */
         },
         "scope": {
             "appender": "resource",
@@ -219,7 +213,8 @@
             "layout": "classic"
         }
     },
-    "mappings": { /*
+    "mappings": { 
+        /*
         "/lucee/": {
             "readonly": "yes",
             "physical": "{lucee-config}/context/",
@@ -247,7 +242,9 @@
             "inspectTemplate": "once",
             "topLevel": "true",
             "readOnly": "true"
-        } */},
+        } 
+        */
+    },
     "remoteClients": {
         "directory": "{lucee-config}remote-client/"
     },

--- a/devops/.CFconfig-download.json5
+++ b/devops/.CFconfig-download.json5
@@ -131,17 +131,38 @@
             "level": "error",
             "layout": "classic"
         },
-        "exception": {
-            "appender": "resource",
-            "appenderArguments": "path:{lucee-config}/logs/exception.log",
+        "update-provider": {
+            "appenderArguments": "environment:%7Benv%2ESENTRY%5FENV%7D;dist:;extras:;dsn:%7Benv%2ESENTRY%5FDSN%7D;debug:true;tags",
             "level": "error",
-            "layout": "classic"
+            "appenderClass": "org.lucee.extension.sentry.log.log4j.SentryAppenderLog4j2",
+            "appenderBundleName": "sentry.extension",
+            "appenderBundleVersion": "5.5.2.12-BETA",
+            "layoutClass": "lucee.commons.io.log.log4j2.layout.ClassicLayout",
+            "layoutArguments": ""
+        },
+        "exception": {
+            "appenderArguments": "environment:%7Benv%2ESENTRY%5FENV%7D;dist:;extras:;dsn:%7Benv%2ESENTRY%5FDSN%7D;debug:true;tags",
+            "level": "error",
+            "appenderClass": "org.lucee.extension.sentry.log.log4j.SentryAppenderLog4j2",
+            "appenderBundleName": "sentry.extension",
+            "appenderBundleVersion": "5.5.2.12-BETA",
+            "layoutClass": "lucee.commons.io.log.log4j2.layout.ClassicLayout",
+            "layoutArguments": ""
         },
         "application": {
+            "appenderArguments": "environment:%7Benv%2ESENTRY%5FENV%7D;dist:;extras:;dsn:%7Benv%2ESENTRY%5FDSN%7D;debug:true;tags",
+            "level": "info",
+            "appenderClass": "org.lucee.extension.sentry.log.log4j.SentryAppenderLog4j2",
+            "appenderBundleName": "sentry.extension",
+            "appenderBundleVersion": "5.5.2.12-BETA",
+            "layoutClass": "lucee.commons.io.log.log4j2.layout.ClassicLayout",
+            "layoutArguments": ""
+            /*
             "appender": "resource",
             "appenderArguments": "path:{lucee-config}/logs/application.log",
             "level": "info",
             "layout": "classic"
+            */
         },
         "scope": {
             "appender": "resource",
@@ -198,29 +219,42 @@
             "layout": "classic"
         }
     },
-    "mappings": {},
+    "mappings": { /*
+        "/lucee/": {
+            "readonly": "yes",
+            "physical": "{lucee-config}/context/",
+            "archive": "{lucee-config}/context/lucee-context.lar",
+            "primary": "physical",
+            "listenerMode": "modern",
+            "listenerType": "curr2root",
+            "inspectTemplate": "once"
+        },
+        "/lucee-server/": {
+            "readonly": "yes",
+            "physical": "{lucee-server}/context/",
+            "archive": "",
+            "primary": "physical",
+            "listenerMode": "modern",
+            "listenerType": "curr2root",
+            "inspectTemplate": "once"
+        },
+        "/lucee/admin": {
+            "physical": "{lucee-config}/context/admin",
+            "archive": "{lucee-config}/context/lucee-admin.lar",
+            "primary": "physical",
+            "listenerType": "modern",
+            "listenerMode": "curr2root",
+            "inspectTemplate": "once",
+            "topLevel": "true",
+            "readOnly": "true"
+        } */},
     "remoteClients": {
         "directory": "{lucee-config}remote-client/"
     },
     "resourceProviders": [
         {
-            "scheme": "ftp",
-            "class": "lucee.commons.io.res.type.ftp.FTPResourceProvider",
-            "arguments": "lock-timeout:20000;socket-timeout:-1;client-timeout:60000"
-        },
-        {
             "scheme": "zip",
             "class": "lucee.commons.io.res.type.zip.ZipResourceProvider",
-            "arguments": "lock-timeout:1000;case-sensitive:true;"
-        },
-        {
-            "scheme": "tar",
-            "class": "lucee.commons.io.res.type.tar.TarResourceProvider",
-            "arguments": "lock-timeout:1000;case-sensitive:true;"
-        },
-        {
-            "scheme": "tgz",
-            "class": "lucee.commons.io.res.type.tgz.TGZResourceProvider",
             "arguments": "lock-timeout:1000;case-sensitive:true;"
         },
         {
@@ -267,12 +301,12 @@
             "id": "8D7FB0DF-08BB-1589-FE3975678F07DB17",
             "name": "Compress Tags",
             "version": "1.0.0.15"
-        },
+        } /*
         {
-            "id": "83062C18-FA1F-4647-815BB663BCF98AC0",
-            "name": "Sentry",
-            "version": "5.5.2.12-BETA"
-        }
+            "id": "CED6227E-0F49-6367-A68D21AACA6B07E8",
+            "version": "1.0.0.5",
+            "name": "Lucee Administrator"
+        } */
     ],
     "errorGeneralTemplate": "/lucee/templates/error/error-public.cfm",
     "errorMissingTemplate": "/lucee/templates/error/error-public.cfm",

--- a/devops/.CFconfig-download.json5
+++ b/devops/.CFconfig-download.json5
@@ -136,7 +136,7 @@
             "level": "error",
             "appenderClass": "org.lucee.extension.sentry.log.log4j.SentryAppenderLog4j2",
             "appenderBundleName": "sentry.extension",
-            "appenderBundleVersion": "5.5.2.12-BETA",
+            "appenderBundleVersion": "5.5.2.15",
             "layoutClass": "lucee.commons.io.log.log4j2.layout.ClassicLayout",
             "layoutArguments": ""
         },
@@ -145,7 +145,7 @@
             "level": "error",
             "appenderClass": "org.lucee.extension.sentry.log.log4j.SentryAppenderLog4j2",
             "appenderBundleName": "sentry.extension",
-            "appenderBundleVersion": "5.5.2.12-BETA",
+            "appenderBundleVersion": "5.5.2.15",
             "layoutClass": "lucee.commons.io.log.log4j2.layout.ClassicLayout",
             "layoutArguments": ""
         },
@@ -154,7 +154,7 @@
             "level": "info",
             "appenderClass": "org.lucee.extension.sentry.log.log4j.SentryAppenderLog4j2",
             "appenderBundleName": "sentry.extension",
-            "appenderBundleVersion": "5.5.2.12-BETA",
+            "appenderBundleVersion": "5.5.2.15",
             "layoutClass": "lucee.commons.io.log.log4j2.layout.ClassicLayout",
             "layoutArguments": ""
             /*

--- a/devops/.CFconfig-update.json5
+++ b/devops/.CFconfig-update.json5
@@ -136,7 +136,7 @@
             "level": "error",
             "appenderClass": "org.lucee.extension.sentry.log.log4j.SentryAppenderLog4j2",
             "appenderBundleName": "sentry.extension",
-            "appenderBundleVersion": "5.5.2.12-BETA",
+            "appenderBundleVersion": "5.5.2.15",
             "layoutClass": "lucee.commons.io.log.log4j2.layout.ClassicLayout",
             "layoutArguments": ""
         },
@@ -145,7 +145,7 @@
             "level": "error",
             "appenderClass": "org.lucee.extension.sentry.log.log4j.SentryAppenderLog4j2",
             "appenderBundleName": "sentry.extension",
-            "appenderBundleVersion": "5.5.2.12-BETA",
+            "appenderBundleVersion": "5.5.2.15",
             "layoutClass": "lucee.commons.io.log.log4j2.layout.ClassicLayout",
             "layoutArguments": ""
         },
@@ -154,7 +154,7 @@
             "level": "info",
             "appenderClass": "org.lucee.extension.sentry.log.log4j.SentryAppenderLog4j2",
             "appenderBundleName": "sentry.extension",
-            "appenderBundleVersion": "5.5.2.12-BETA",
+            "appenderBundleVersion": "5.5.2.15",
             "layoutClass": "lucee.commons.io.log.log4j2.layout.ClassicLayout",
             "layoutArguments": ""
             /*
@@ -211,7 +211,7 @@
             "level": "error",
             "appenderClass": "org.lucee.extension.sentry.log.log4j.SentryAppenderLog4j2",
             "appenderBundleName": "sentry.extension",
-            "appenderBundleVersion": "5.5.2.12-BETA",
+            "appenderBundleVersion": "5.5.2.15",
             "layoutClass": "lucee.commons.io.log.log4j2.layout.ClassicLayout",
             "layoutArguments": ""
         },

--- a/devops/.CFconfig-update.json5
+++ b/devops/.CFconfig-update.json5
@@ -157,12 +157,6 @@
             "appenderBundleVersion": "5.5.2.15",
             "layoutClass": "lucee.commons.io.log.log4j2.layout.ClassicLayout",
             "layoutArguments": ""
-            /*
-            "appender": "resource",
-            "appenderArguments": "path:{lucee-config}/logs/application.log",
-            "level": "info",
-            "layout": "classic"
-            */
         },
         "scope": {
             "appender": "resource",
@@ -222,7 +216,8 @@
             "layout": "classic"
         }
     },
-    "mappings": { /*
+    "mappings": { 
+        /*
         "/lucee/": {
             "readonly": "yes",
             "physical": "{lucee-config}/context/",
@@ -250,7 +245,9 @@
             "inspectTemplate": "once",
             "topLevel": "true",
             "readOnly": "true"
-        } */},
+        } 
+        */
+    },
     "remoteClients": {
         "directory": "{lucee-config}remote-client/"
     },

--- a/devops/.CFconfig-update.json5
+++ b/devops/.CFconfig-update.json5
@@ -131,12 +131,17 @@
             "level": "error",
             "layout": "classic"
         },
+        "update-provider": {
+            "appenderArguments": "environment:%7Benv%2ESENTRY%5FENV%7D;dist:;extras:;dsn:%7Benv%2ESENTRY%5FDSN%7D;debug:true;tags",
+            "level": "error",
+            "appenderClass": "org.lucee.extension.sentry.log.log4j.SentryAppenderLog4j2",
+            "appenderBundleName": "sentry.extension",
+            "appenderBundleVersion": "5.5.2.12-BETA",
+            "layoutClass": "lucee.commons.io.log.log4j2.layout.ClassicLayout",
+            "layoutArguments": ""
+        },
         "exception": {
-            "appenderArguments": {
-                "environment": "{env:SENTRY_ENV}",
-                "dsn": "{env:SENTRY_DSN}",
-                "debug": true
-            },
+            "appenderArguments": "environment:%7Benv%2ESENTRY%5FENV%7D;dist:;extras:;dsn:%7Benv%2ESENTRY%5FDSN%7D;debug:true;tags",
             "level": "error",
             "appenderClass": "org.lucee.extension.sentry.log.log4j.SentryAppenderLog4j2",
             "appenderBundleName": "sentry.extension",
@@ -145,30 +150,20 @@
             "layoutArguments": ""
         },
         "application": {
-            "appenderArguments": {
-                "environment": "{env:SENTRY_ENV}",
-                "dsn": "{env:SENTRY_DSN}",
-                "debug": true
-            },
+            "appenderArguments": "environment:%7Benv%2ESENTRY%5FENV%7D;dist:;extras:;dsn:%7Benv%2ESENTRY%5FDSN%7D;debug:true;tags",
             "level": "info",
             "appenderClass": "org.lucee.extension.sentry.log.log4j.SentryAppenderLog4j2",
             "appenderBundleName": "sentry.extension",
             "appenderBundleVersion": "5.5.2.12-BETA",
             "layoutClass": "lucee.commons.io.log.log4j2.layout.ClassicLayout",
             "layoutArguments": ""
+            /*
+            "appender": "resource",
+            "appenderArguments": "path:{lucee-config}/logs/application.log",
+            "level": "info",
+            "layout": "classic"
+            */
         },
-        // "exception": {
-        //     "appender": "resource",
-        //     "appenderArguments": "path:{lucee-config}/logs/exception.log",
-        //     "level": "error",
-        //     "layout": "classic"
-        //   },
-        //   "application": {
-        //     "appender": "resource",
-        //     "appenderArguments": "path:{lucee-config}/logs/application.log",
-        //     "level": "info",
-        //     "layout": "classic"
-        //   },
         "scope": {
             "appender": "resource",
             "appenderArguments": "path:{lucee-config}/logs/scope.log",
@@ -212,10 +207,13 @@
             "layout": "classic"
         },
         "rest": {
-            "appender": "resource",
-            "appenderArguments": "path:{lucee-config}/logs/rest.log",
+            "appenderArguments": "environment:%7Benv%2ESENTRY%5FENV%7D;dist:;extras:;dsn:%7Benv%2ESENTRY%5FDSN%7D;debug:true;tags",
             "level": "error",
-            "layout": "classic"
+            "appenderClass": "org.lucee.extension.sentry.log.log4j.SentryAppenderLog4j2",
+            "appenderBundleName": "sentry.extension",
+            "appenderBundleVersion": "5.5.2.12-BETA",
+            "layoutClass": "lucee.commons.io.log.log4j2.layout.ClassicLayout",
+            "layoutArguments": ""
         },
         "mapping": {
             "appender": "resource",
@@ -224,7 +222,7 @@
             "layout": "classic"
         }
     },
-    "mappings": {
+    "mappings": { /*
         "/lucee/": {
             "readonly": "yes",
             "physical": "{lucee-config}/context/",
@@ -252,30 +250,14 @@
             "inspectTemplate": "once",
             "topLevel": "true",
             "readOnly": "true"
-        }
-    },
+        } */},
     "remoteClients": {
         "directory": "{lucee-config}remote-client/"
     },
     "resourceProviders": [
         {
-            "scheme": "ftp",
-            "class": "lucee.commons.io.res.type.ftp.FTPResourceProvider",
-            "arguments": "lock-timeout:20000;socket-timeout:-1;client-timeout:60000"
-        },
-        {
             "scheme": "zip",
             "class": "lucee.commons.io.res.type.zip.ZipResourceProvider",
-            "arguments": "lock-timeout:1000;case-sensitive:true;"
-        },
-        {
-            "scheme": "tar",
-            "class": "lucee.commons.io.res.type.tar.TarResourceProvider",
-            "arguments": "lock-timeout:1000;case-sensitive:true;"
-        },
-        {
-            "scheme": "tgz",
-            "class": "lucee.commons.io.res.type.tgz.TGZResourceProvider",
             "arguments": "lock-timeout:1000;case-sensitive:true;"
         },
         {
@@ -322,17 +304,12 @@
             "id": "8D7FB0DF-08BB-1589-FE3975678F07DB17",
             "name": "Compress Tags",
             "version": "1.0.0.15"
-        },
-        {
-            "id": "83062C18-FA1F-4647-815BB663BCF98AC0",
-            "name": "Sentry",
-            "version": "5.5.2.12-BETA"
-        },
+        } /*
         {
             "id": "CED6227E-0F49-6367-A68D21AACA6B07E8",
-            "name": "Lucee Administrator",
-            "version": "1.0.0.5"
-        }
+            "version": "1.0.0.5",
+            "name": "Lucee Administrator"
+        } */
     ],
     "rest": {
         "mapping": [

--- a/devops/Dockerfile.base
+++ b/devops/Dockerfile.base
@@ -4,7 +4,7 @@ ENV JAVA_OPTS="-javaagent:/opt/lucee/bin/prometheus-java-agent.jar=9090:/opt/luc
 ENV LUCEE_ADMIN_ENABLED=false
 RUN  mkdir -p /opt/lucee/server/lucee-server/deploy && \
 mkdir -p /opt/lucee/server/lucee-server/context && \
-wget -nv https://ext.lucee.org/sentry-extension-5.5.2.12-BETA.lex -O /opt/lucee/server/lucee-server/deploy/sentry-extension.lex
+wget -nv https://ext.lucee.org/sentry-extension-5.5.2.15.lex -O /opt/lucee/server/lucee-server/deploy/sentry-extension.lex
 
 RUN mkdir -p /var/www && mkdir -p /var/www/logs \
 && ln -sf /proc/1/fd/1 /opt/lucee/server/lucee-server/context/logs/application.log \

--- a/devops/Dockerfile.base
+++ b/devops/Dockerfile.base
@@ -23,7 +23,6 @@ RUN mkdir -p /var/www && mkdir -p /var/www/logs \
 && ln -sf /proc/1/fd/1 /opt/lucee/server/lucee-server/context/logs/thread.log
 
 
-ENV LUCEE_ADMIN_ENABLED=false
 ENV LUCEE_SECURITY_LIMITEVALUATION=true
 COPY devops/conf/prometheus/config.yml /opt/lucee/conf/prometheus/config.yml
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD [ "curl", "-f", "http://localhost:8888/update/healthcheck/index.cfm" ]

--- a/devops/Dockerfile.download
+++ b/devops/Dockerfile.download
@@ -1,8 +1,4 @@
 # syntax = edrevo/dockerfile-plus
 INCLUDE+ ./devops/Dockerfile.base
-ARG SENTRY_ENV
-ARG SENTRY_DSN
-ENV SENTRY_ENV=${SENTRY_ENV}
-ENV SENTRY_DSN=${SENTRY_DSN}
 COPY ./download /var/www
-COPY ./devops/.CFconfig-download.json /opt/lucee/server/lucee-server/context/.CFConfig.json
+COPY ./devops/.CFconfig-download.json5 /opt/lucee/server/lucee-server/context/.CFConfig.json

--- a/devops/Dockerfile.update
+++ b/devops/Dockerfile.update
@@ -1,11 +1,6 @@
 # syntax = edrevo/dockerfile-plus
 INCLUDE+ ./devops/Dockerfile.base
-
-ARG SENTRY_ENV
-ARG SENTRY_DSN
-ENV SENTRY_ENV=${SENTRY_ENV}
-ENV SENTRY_DSN=${SENTRY_DSN}
 COPY ./root /var/www
 COPY ./update /var/www/update
 COPY ./extension /var/www/extension
-COPY ./devops/.CFconfig-update.json /opt/lucee/server/lucee-server/context/.CFConfig.json
+COPY ./devops/.CFconfig-update.json5 /opt/lucee/server/lucee-server/context/.CFConfig.json

--- a/extension/ExtensionProvider.cfc
+++ b/extension/ExtensionProvider.cfc
@@ -22,7 +22,10 @@
 	
 	private function logger( string text, any exception, type="info" ){
 		var log = arguments.text & chr(13) & chr(10) & callstackGet('string');
-		WriteLog( text=log, type=arguments.type, log=variables.providerLog, exception=arguments.exception );
+		if ( !isNull(arguments.exception ) )
+			WriteLog( text=log, type=arguments.type, log=variables.providerLog, exception=arguments.exception );
+		else
+			WriteLog( text=log, type=arguments.type, log=variables.providerLog );
 	}
 
 	/**

--- a/extension/ExtensionProvider.cfc
+++ b/extension/ExtensionProvider.cfc
@@ -5,6 +5,7 @@
 
 	variables.EXPIRE=300*1000; // MS
 
+	variables.providerLog = "update-provider";
 	variables.current=getDirectoryFromPath(getCurrentTemplatePath());
 	variables.extensionDir=variables.current&"extensions/";
 	variables.ext="lex";
@@ -19,6 +20,10 @@
 	variables.cdnURL="https://ext.lucee.org/";
 	variables.current=getDirectoryFromPath(getCurrentTemplatePath());
 	
+	private function logger( string text, string stack="", type="info" ){
+		var log = arguments.text & chr(13) & chr(10) & callStackGet('string') & chr(13) & chr(10) & arguments.stack;
+		WriteLog( text=log, type=arguments.type, log=variables.providerLog );
+	}
 
 	/**
 	* if there is a update the function is returning a struct like this:
@@ -534,6 +539,7 @@
 			var text="extension for id ["&arguments.id&"] "&(arguments.version.len()==0?"":("in version "&arguments.version))&" not found as "&type&" version";
 			
 			header statuscode="404" statustext="#text#";
+			logger (text, type="error");
 			echo(text);
 		}
 		

--- a/extension/ExtensionProvider.cfc
+++ b/extension/ExtensionProvider.cfc
@@ -20,9 +20,9 @@
 	variables.cdnURL="https://ext.lucee.org/";
 	variables.current=getDirectoryFromPath(getCurrentTemplatePath());
 	
-	private function logger( string text, string stack="", type="info" ){
-		var log = arguments.text & chr(13) & chr(10) & callStackGet('string') & chr(13) & chr(10) & arguments.stack;
-		WriteLog( text=log, type=arguments.type, log=variables.providerLog );
+	private function logger( string text, any exception, type="info" ){
+		var log = arguments.text & chr(13) & chr(10) & callstackGet('string');
+		WriteLog( text=log, type=arguments.type, log=variables.providerLog, exception=arguments.exception );
 	}
 
 	/**

--- a/update/UpdateProvider.cfc
+++ b/update/UpdateProvider.cfc
@@ -406,7 +406,7 @@ try{
 						// TODO variables.extMappings is never defined!
 						if(!isnull(variables.extMappings) && structKeyExists(variables.extMappings,arguments.bundleName)) {
 							if(isDefined("url.xc10")) 
-								throw ()"we have a mapping "&serialize(variables.extMappings[arguments.bundleName]));
+								throw ("we have a mapping "&serialize(variables.extMappings[arguments.bundleName]));
 							var map=variables.extMappings[arguments.bundleName];
 							var trgName=arguments.bundleName&"-"&arguments.bundleVersion&".jar";
 							fff&=jars.name&":"&(len(jars.name)>len(map.jar))&":"&left(jars.name,len(map.jar))&" :: "&jars.name&">"&map.jar&";";

--- a/update/UpdateProvider.cfc
+++ b/update/UpdateProvider.cfc
@@ -24,9 +24,9 @@
 		directoryCreate(variables.artDirectory);
 	variables.extDirectory="/var/www/extension/extension/"; // TODO make more dynamic
 
-	private function logger( string text, string stack="", type="info" ){
-		var log = arguments.text & chr(13) & chr(10) & callstackGet('string') & chr(13) & chr(10) & arguments.stack;
-		WriteLog( text=log, type=arguments.type, log=variables.providerLog );
+	private function logger( string text, any exception, type="info" ){
+		var log = arguments.text & chr(13) & chr(10) & callstackGet('string');
+		WriteLog( text=log, type=arguments.type, log=variables.providerLog, exception=arguments.exception );
 	}
 
 		/**
@@ -67,7 +67,8 @@
 			var versions=s3.getVersions();
 			var keys=structKeyArray(versions);
 			arraySort(keys,"textnocase");
-			var latest.version = versions[keys[arrayLen(keys)]].version;
+			var latest = {};
+			latest.version = versions[keys[arrayLen(keys)]].version;
 			var latestVersion=toVersion(latest.version);
 			
 			// others
@@ -78,10 +79,10 @@
 				for(var i=arrayLen(keys);i>=1;i--) {
 					var el=versions[keys[i]];
 					if(findNoCase("-SNAPSHOT",el.version)) {
-						if((--maxSnap)<=0) continue;
+						if ( ( --maxSnap )<=0 ) continue;
 					}
 					else {
-						if((--maxRel)<=0) continue;
+						if ( ( --maxRel )<=0 ) continue;
 					}
 					arrayPrepend(latest.otherVersions,el.version);
 				}
@@ -134,7 +135,7 @@
 			}; // TODO get the right version for given version
 		}
 		catch(e){
-			logger( text=e.message, stack=e.stacktrace, type="error" );
+			logger( text=e.message, exception=e, type="error" );
 			return {"type":"error","message":e.message,cfcatch:e};
 		}
 	}
@@ -309,7 +310,7 @@ try{
 				e.message&"
 ");			
 
-			logger(text="Maven matcher missing bundle: " & arguments.bundleName & ":" & arguments.bundleVersion, stack=e.stacktrace, type="error" );
+			logger(text="Maven matcher missing bundle: " & arguments.bundleName & ":" & arguments.bundleVersion, exception=e, type="error" );
 			
 		}
 		
@@ -404,7 +405,8 @@ try{
 						}
 						// TODO variables.extMappings is never defined!
 						if(!isnull(variables.extMappings) && structKeyExists(variables.extMappings,arguments.bundleName)) {
-							if(isDefined("url.xc10")) throw "we have a mapping "&serialize(variables.extMappings[arguments.bundleName]);
+							if(isDefined("url.xc10")) 
+								throw ()"we have a mapping "&serialize(variables.extMappings[arguments.bundleName]));
 							var map=variables.extMappings[arguments.bundleName];
 							var trgName=arguments.bundleName&"-"&arguments.bundleVersion&".jar";
 							fff&=jars.name&":"&(len(jars.name)>len(map.jar))&":"&left(jars.name,len(map.jar))&" :: "&jars.name&">"&map.jar&";";
@@ -489,7 +491,8 @@ try{
 
 				
 			if(!isNull(redirectURL)){
-				if(isDefined("url.xa1")) throw jsonPath&":"&redirectURL;
+				if(isDefined("url.xa1")) 
+					throw (jsonPath&":"&redirectURL);
 				filewrite(
 					jsonPath,
 					serialize({"jar":redirectURL,"local":path}));
@@ -528,7 +531,7 @@ try{
 		}
 }
 catch(e) { 
-	logger (text=e.message, stack=e.stacktrace, type="error");
+	logger(text=e.message, exception=e, type="error");
 	return e;
 }
 		}
@@ -799,7 +802,7 @@ catch(e) {
 		catch(e){
 			systemOutput( e, 1, 1 );
 			header statuscode="500";
-			logger (text=e.message, stack=e.stacktrace, type="error");
+			logger(text=e.message, exception=e, type="error");
 			echo (e.message);
 		}
 	}
@@ -841,7 +844,7 @@ catch(e) {
 		}
 		catch(e){
 			systemOutput( e, 1, 1 );
-			logger ( error=e.message, stack=e.stacktrace, type="error" );
+			logger( error=e.message, exception=e, type="error" );
 			return {"type":"error","message":e.message};
 		}
 	}
@@ -887,7 +890,7 @@ catch(e) {
 				return parseDateTime(info.sources.jar.date);
 		} catch(e) {
 			var mess=  "maven.getDate() threw " & cfcatch.message;
-			logger (text=mess, type="error");
+			logger(text=mess, exception=e, type="error");
 			systemOutput(mess, true, true );
 		}
 		
@@ -975,7 +978,7 @@ catch(e) {
 		}
 		if(arr.len()!=4 || !isNumeric(arr[1]) || !isNumeric(arr[2]) || !isNumeric(arr[3])) {
 			if(ignoreInvalidVersion) return {};
-			throw "version number ["&arguments.version&"] is invalid";
+			throw ("version number ["&arguments.version&"] is invalid");
 		}
 		local.sct={major:arr[1]+0,minor:arr[2]+0,micro:arr[3]+0,qualifier_appendix:"",qualifier_appendix_nbr:100};
 
@@ -989,7 +992,7 @@ catch(e) {
 			else if(sct.qualifier_appendix=="BETA")sct.qualifier_appendix_nbr=50;
 			else sct.qualifier_appendix_nbr=75; // every other appendix is better than SNAPSHOT
 		}
-		else throw "version number ["&arguments.version&"] is invalid";
+		else throw ("version number ["&arguments.version&"] is invalid");
 		sct.pure=
 					sct.major
 					&"."&sct.minor
@@ -1063,7 +1066,8 @@ catch(e) {
 	private function fromS3(path,name,async=true) {
 		
 		// if exist we redirect to it
-			if(!isNull(url.show)) throw (!isNull(application.exists[name]) && application.exists[name])&":"&fileExists(variables.s3Root&name)&"->"&(variables.s3Root&name);
+			if(!isNull(url.show))
+				throw ((!isNull(application.exists[name]) && application.exists[name])&":"&fileExists(variables.s3Root&name)&"->"&(variables.s3Root&name));
 
 			var hasDef=(!isNull(application.exists[name]) && application.exists[name]);
 			if(hasDef || fileExists(variables.s3Root&name)) {
@@ -1089,7 +1093,8 @@ catch(e) {
 					lock timeout=1000 name=src {
 						if(!fileExists(trg) && fileSize(src)>100000) {// we do this because it was created by a thread blocking this thread
 							_fileCopy(src,trg);
-							if(!isNull(url.show)) throw "fileExists: "&fileExists(src)&" + "&fileExists(trg);
+							if(!isNull(url.show))
+								throw ("fileExists: "&fileExists(src)&" + "&fileExists(trg));
 						}
 					}
 				}	
@@ -1109,7 +1114,8 @@ catch(e) {
 
 			}
 			//throw src&":"&res.statuscode&":"&len(res.filecontent);
-			if(isNull(res.statuscode) || res.statuscode!=200) throw src&":"&res.statuscode;
+			if(isNull(res.statuscode) || res.statuscode!=200) 
+				throw (src & ":" & res.statuscode);
 			if(len(res.filecontent)<1000) throw "file [#src#] is to small (#len(res.filecontent)#)";
 			fileWrite(trg,res.filecontent);
 		}
@@ -1152,7 +1158,7 @@ catch(e) {
 		local.arr=listToArray(arguments.version,'.');
 		
 		if(arr.len()!=4 || !isNumeric(arr[1]) || !isNumeric(arr[2]) || !isNumeric(arr[3])) {
-			throw "version number ["&arguments.version&"] is invalid";
+			throw ("version number ["&arguments.version&"] is invalid");
 		}
 		local.sct={major:arr[1]+0,minor:arr[2]+0,micro:arr[3]+0,qualifier_appendix:"",qualifier_appendix_nbr:100};
 

--- a/update/UpdateProvider.cfc
+++ b/update/UpdateProvider.cfc
@@ -26,7 +26,10 @@
 
 	private function logger( string text, any exception, type="info" ){
 		var log = arguments.text & chr(13) & chr(10) & callstackGet('string');
-		WriteLog( text=log, type=arguments.type, log=variables.providerLog, exception=arguments.exception );
+		if ( !isNull(arguments.exception ) )
+			WriteLog( text=log, type=arguments.type, log=variables.providerLog, exception=arguments.exception );
+		else
+			WriteLog( text=log, type=arguments.type, log=variables.providerLog );
 	}
 
 		/**


### PR DESCRIPTION
- renamed src .CFConfig files to .json5, no more complaining about comments
- providers now log to a custom log file, update-provider
- sentry logs out rest, application, update-provider and exception (would like to remove application as it's noisy)