### PR TITLE
LDEV-4949 serve extensions directly for older versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ update/WEB-INF
 update/log-maven-download.log
 update/missing-bundles.txt
 /tests/artifacts
+/apps/updateserver/rest/cache

--- a/apps/updateserver/Application.cfc
+++ b/apps/updateserver/Application.cfc
@@ -72,6 +72,8 @@ component {
 			, mavenMatcher        = new services.legacy.MavenMatcher()
 		);
 
+		var extensionCache = new services.ExtensionCache();
+
 		extMetaReader.setBundleDownloadservice( bundleDownloadService );
 		extMetaReader.loadMeta();
 
@@ -83,6 +85,7 @@ component {
 		application.extensionsCdnUrl      = extCdnUrl;
 		application.extensionsS3Root      = extS3Root;
 		application.extMetaReader         = extMetaReader;
+		application.extensionCache        = extensionCache;
 		application.bundleDownloadService = bundleDownloadService;
 		application.jiraChangelogService  = jiraChangelogService;
 	}

--- a/apps/updateserver/services/ExtensionCache.cfc
+++ b/apps/updateserver/services/ExtensionCache.cfc
@@ -1,0 +1,36 @@
+component accessors=true {
+
+	property name="extensionCache"        type="any" default="cache/extensions/";
+
+	function getExtensionLex( extensionUrl ){
+		var filename = listLast( arguments.extensionUrl, "/");
+		var cachedir =  expandPath( variables.extensionCache );
+
+		if ( !directoryExists( cachedir ) ){
+			directoryCreate( cachedir );
+		} else if ( fileExists ( cachedir & filename )) {
+			return cachedir & filename;
+		}
+		lock name="ext-#filename#" type="exclusive" timeout=10 {
+			 return _fetchExtensionLex( cachedir, arguments.extensionUrl )
+		}
+
+		if ( fileExists ( cachedir & filename ) ) {
+			return cachedir & filename;
+		}
+		throw "unable to find extension [#filename#]";
+	}
+
+	private function _fetchExtensionLex( string cachedir, string extensionUrl ){
+		var filename = listLast( arguments.extensionUrl, "/");
+		if ( fileExists ( cachedir & filename )) {
+			return cachedir & filename;
+		}
+		systemOutput( "Downloading #arguments.extensionUrl# (cache miss)", true);
+		http url=arguments.extensionUrl method="get" result="local.core" path=cachedir;
+		var file = directoryList(path=cachedir, filter="#filename#");
+		// systemOutput(file, true);
+		return file[ 1 ];
+	}
+
+}

--- a/tests/testExtensionDownload.cfc
+++ b/tests/testExtensionDownload.cfc
@@ -1,0 +1,38 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="data-provider-integration" {
+
+	function beforeAll (){
+		variables.dir = getDirectoryFromPath(getCurrentTemplatePath());
+		application action="update" mappings={
+			"/services" : expandPath( dir & "../apps/updateserver/services" )
+		};
+		variables.artifacts = dir & "/artifacts";
+		if ( !DirectoryExists( variables.artifacts ))
+			directoryCreate( variables.artifacts );
+
+		variables.buildDir = getTempDirectory() & "/build-test-#createUniqueId()#/";
+		if ( DirectoryExists( variables.buildDir ) )
+			directoryDelete( variables.buildDir, true );
+		directoryCreate( variables.buildDir, true );
+
+	}
+
+	function run( testResults , testBox ) {
+		describe( "extensions need to be served directly for older lucee versions", function() {
+			it(title="check local extension cache works", body=function(){
+				var extensionCache = new services.extensionCache();
+				var path = extensionCache.getExtensionLex( "https://ext.lucee.org/compress-extension-1.0.0.15.lex" );
+				systemOutput( path, true )
+				expect( fileExists( path ) ).toBeTrue();
+			});
+
+			it(title="check local extension cache works (from cache)", body=function(){
+				var extensionCache = new services.extensionCache();
+				var path = extensionCache.getExtensionLex( "https://ext.lucee.org/compress-extension-1.0.0.15.lex" );
+				// systemOutput( path, true )
+				expect( fileExists( path ) ).toBeTrue();
+			});
+
+		});
+	}
+
+}


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-4949

http://localhost:8889/rest/extension/provider/full/8D7FB0DF-08BB-1589-FE3975678F07DB17/
allowRedirect depends on http vs https

http://localhost:8889/rest/extension/provider/full/8D7FB0DF-08BB-1589-FE3975678F07DB17/?allowRedirect=false

http://localhost:8889/rest/extension/provider/full/8D7FB0DF-08BB-1589-FE3975678F07DB17/?allowRedirect=true

requires port 80 to be open as well

test included

```
     [java]    [script] 	testAdditional.testExtensionDownload Downloading https://ext.lucee.org/compress-extension-1.0.0.15.lex (cache miss)
     [java]    [script] /home/runner/work/lucee-data-provider/lucee-data-provider/lucee/test/cache/extensions/compress-extension-1.0.0.15.lex
     [java]    [script] 	 (2 tests passed in 251 ms)
```