### PR TITLE
docs: fix typo in lucee.jar tooltip

### DIFF
--- a/apps/download/index.cfm
+++ b/apps/download/index.cfm
@@ -193,7 +193,7 @@
 	   lang.core='The Lucee Core file, you can simply copy this to the "patches" folder of your existing Lucee installation.';
 	   lang.jar='The Lucee jar #jarInfo#, simply copy that file to the lib (classpath) folder of your servlet engine.';
 	   lang.dependencies='Dependencies (3 party bundles) Lucee needs for this release, simply copy this to "/lucee-server/bundles" of your installation (If this files are not present Lucee will download them).';
-	   lang.jar='Lucee jar file without dependencies Lucee needs to run. Simply copy this file to your servlet engine lib folder (classpath). If dependecy bundles are not in place Lucee will download them.';
+	   lang.jar='Lucee jar file without dependencies Lucee needs to run. Simply copy this file to your servlet engine lib folder (classpath). If dependency bundles are not in place Lucee will download them.';
 	   lang.luceeAll='Lucee jar file that contains all dependencies Lucee needs to run. Simply copy this file to your servlet engine lib folder (classpath)';
 	   
 	   lang.lib="The Lucee Jar file, you can simply copy to your existing installation to update to Lucee 5. This file comes in 2 favors, the ""lucee.jar"" that only contains Lucee itself and no dependecies (Lucee will download dependencies if necessary) or the lucee-all.jar with all dependencies Lucee needs bundled (not availble for versions before 5.0.0.112).";


### PR DESCRIPTION
This PR fixes small typo in tooltip for lucee.jar downloads.

- dependecy -> dependency

<img width="405" alt="typo_screenshot" src="https://github.com/user-attachments/assets/53c08ed9-1d81-4b04-9064-ae5d47b561de">
